### PR TITLE
Use default InstanceType=t2.small

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+dist: trusty
 language: python
 python:
   - "2.7"

--- a/etcd-cluster-multiregion.yaml
+++ b/etcd-cluster-multiregion.yaml
@@ -6,7 +6,7 @@ SenzaComponents:
     AssociatePublicIpAddress: true
     IamRoles:
     - Ref: EtcdRole
-    InstanceType: t2.micro
+    InstanceType: t2.small
     SecurityGroups:
     - Fn::GetAtt:
       - EtcdSecurityGroup
@@ -25,7 +25,7 @@ SenzaComponents:
           partition: none
           filesystem: tmpfs
           erase_on_boot: false
-          options: size=512m
+          options: size=1024m
       appdynamics_application: 'etcd-cluster-{{Arguments.version}}'
     Type: Senza::TaupageAutoScalingGroup
     AutoScaling:

--- a/etcd-cluster.yaml
+++ b/etcd-cluster.yaml
@@ -4,7 +4,7 @@ SenzaComponents:
 - AppServer:
     IamRoles:
     - Ref: EtcdRole
-    InstanceType: t2.micro
+    InstanceType: t2.small
     SecurityGroups:
     - Fn::GetAtt:
       - EtcdSecurityGroup
@@ -22,7 +22,7 @@ SenzaComponents:
           partition: none
           filesystem: tmpfs
           erase_on_boot: false
-          options: size=512m
+          options: size=1024m
       appdynamics_application: 'etcd-cluster-{{Arguments.version}}'
     Type: Senza::TaupageAutoScalingGroup
     AutoScaling:

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ class PyTest(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
         if self.cov_xml or self.cov_html:
-            self.cov = ['--cov', MAIN_SCRIPT, '--cov-report', 'term-missing']
+            self.cov = ['--cov', MAIN_SCRIPT[:-3], '--cov-report', 'term-missing']
             if self.cov_xml:
                 self.cov.extend(['--cov-report', 'xml'])
             if self.cov_html:
@@ -117,7 +117,7 @@ def setup_package():
         test_suite='tests',
         packages=[],
         install_requires=get_install_requirements('requirements.txt'),
-        setup_requires=['flake8==2.6.0'],
+        setup_requires=['flake8'],
         cmdclass=cmdclass,
         tests_require=['pytest-cov', 'pytest', 'mock'],
         command_options=command_options,


### PR DESCRIPTION
On t2.micro it is not enough memory. Also it runs out of cpu credits on the leader node when transaction rate is high.